### PR TITLE
Added an implicit view from a type T to JValue

### DIFF
--- a/codecs/json4s/src/main/scala/muster/codec/json4s/Json4sCodec.scala
+++ b/codecs/json4s/src/main/scala/muster/codec/json4s/Json4sCodec.scala
@@ -11,4 +11,9 @@ object Json4sCodec extends JValueRenderer with InputFormat[Consumable[JValue], J
       override def hasNextNode: Boolean = false
       protected def node = source
   }
+
+  implicit def musterJson4sDSLSerializer[T](f: T)(implicit evidence:Producer[T]): JValue = {
+    Json4sCodec.from(f)
+  }
+  
 }


### PR DESCRIPTION
Allows you to use the Json4s DSL with any type that muster is able to serialize, i.e.

``` scala
  case class Rawr(a:String,b:Int)
  val someCaseClass = Rawr("a",34)
  val json = ("a" -> someCaseClass) ~ ("c" -> 4)
```
